### PR TITLE
fix cache settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ function Favicons(inputPaths, options) {
   this.imagePath = options.imagePath || 'favicon.png';
   this.htmlCallback = options.htmlCallback || function() {};
   Plugin.call(this, inputPaths, {
-    annotation: options.annotation
+    annotation: "Broccoli-Favicon",
+    cacheInclude: [/\.(png|jpg|jpeg|ico)/i]
   });
 }
 Favicons.prototype = Object.create(Plugin.prototype);
@@ -69,4 +70,3 @@ Favicons.prototype.build = function build() {
 }
 
 module.exports = Favicons;
-


### PR DESCRIPTION
Currently, none of the favicons are getting cached, so every sequential build is _extremely slow_ as in on the order of minutes. This should handle the correct caching on 1.0.0-beta.2.
