### PR TITLE
Expose raw objects to onSuccess hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3543,7 +3543,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
       "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
-      "dev": true,
       "requires": {
         "rsvp": "~3.2.1"
       },
@@ -3551,8 +3550,7 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
     },
@@ -3560,7 +3558,6 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
       "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
-      "dev": true,
       "requires": {
         "debug": "^2.2.0",
         "heimdalljs": "^0.2.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3566,6 +3566,11 @@
         "heimdalljs": "^0.2.6"
       }
     },
+    "himalaya": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/himalaya/-/himalaya-1.1.0.tgz",
+      "integrity": "sha512-LLase1dHCRMel68/HZTFft0N0wti0epHr3nNY7ynpLbyZpmrKMQ8YIpiOV77TM97cNpC8Wb2n6f66IRggwdWPw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "broccoli-caching-writer": "3.0.3",
     "favicons": "~5.1.1",
+    "himalaya": "1.1.0",
     "lodash.merge": "~4.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "broccoli-caching-writer": "3.0.3",
     "favicons": "~5.1.1",
+    "heimdalljs-logger": "^0.1.10",
     "himalaya": "1.1.0",
     "lodash.merge": "~4.6.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,6 @@ import deepMerge from 'lodash.merge';
 import { parse as parseHtml } from 'himalaya';
 import { default as _logger } from 'heimdalljs-logger';
 
-import config from './config';
-import { default as _logger } from 'heimdalljs-logger';
-
 const logger = _logger('broccoli-favicon');
 
 export default class Favicon extends Plugin {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,9 @@ import fs from 'fs';
 import path from 'path';
 import deepMerge from 'lodash.merge';
 import { parse as parseHtml } from 'himalaya';
+import { default as _logger } from 'heimdalljs-logger';
 
+const logger = _logger('broccoli-favicon');
 
 export default class Favicon extends Plugin {
   constructor(node, options = {}) {
@@ -24,6 +26,7 @@ export default class Favicon extends Plugin {
     iconPath = path.join(this.inputPaths[0], iconPath);
 
     if (!fs.existsSync(iconPath)) {
+      logger.warn(`Favicon file has been not detected in specified path: "${iconPath}"`);
       return Promise.resolve()
     }
 

--- a/tests/fixtures/mocks.js
+++ b/tests/fixtures/mocks.js
@@ -1,0 +1,714 @@
+const rawObjectsMock = [
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"114x114"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-114x114.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"120x120"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-120x120.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"144x144"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-144x144.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"152x152"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-152x152.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"180x180"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-180x180.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"57x57"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-57x57.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"60x60"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-60x60.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"72x72"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-72x72.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-icon"
+         },
+         {
+            "key":"sizes",
+            "value":"76x76"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-icon-76x76.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-320x460.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-640x920.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-640x1096.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-750x1294.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 414px) and (device-height: 736px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 3)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-1182x2208.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 414px) and (device-height: 736px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 3)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-1242x2148.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 1)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-748x1024.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 2)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-1496x2048.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 1)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-768x1004.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"apple-touch-startup-image"
+         },
+         {
+            "key":"media",
+            "value":"(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 2)"
+         },
+         {
+            "key":"href",
+            "value":"/apple-touch-startup-image-1536x2008.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"icon"
+         },
+         {
+            "key":"type",
+            "value":"image/png"
+         },
+         {
+            "key":"sizes",
+            "value":"16x16"
+         },
+         {
+            "key":"href",
+            "value":"/favicon-16x16.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"icon"
+         },
+         {
+            "key":"type",
+            "value":"image/png"
+         },
+         {
+            "key":"sizes",
+            "value":"228x228"
+         },
+         {
+            "key":"href",
+            "value":"/coast-228x228.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"icon"
+         },
+         {
+            "key":"type",
+            "value":"image/png"
+         },
+         {
+            "key":"sizes",
+            "value":"32x32"
+         },
+         {
+            "key":"href",
+            "value":"/favicon-32x32.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"manifest"
+         },
+         {
+            "key":"href",
+            "value":"/manifest.json"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"shortcut icon"
+         },
+         {
+            "key":"href",
+            "value":"/favicon.ico"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"link",
+      "attributes":[
+         {
+            "key":"rel",
+            "value":"yandex-tableau-widget"
+         },
+         {
+            "key":"href",
+            "value":"/yandex-browser-manifest.json"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"apple-mobile-web-app-capable"
+         },
+         {
+            "key":"content",
+            "value":"yes"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"apple-mobile-web-app-status-bar-style"
+         },
+         {
+            "key":"content",
+            "value":"black-translucent"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"apple-mobile-web-app-title"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"application-name"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"mobile-web-app-capable"
+         },
+         {
+            "key":"content",
+            "value":"yes"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"msapplication-TileColor"
+         },
+         {
+            "key":"content",
+            "value":"#fff"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"msapplication-TileImage"
+         },
+         {
+            "key":"content",
+            "value":"/mstile-144x144.png"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"msapplication-config"
+         },
+         {
+            "key":"content",
+            "value":"/browserconfig.xml"
+         }
+      ],
+      "children":[
+
+      ]
+   },
+   {
+      "type":"element",
+      "tagName":"meta",
+      "attributes":[
+         {
+            "key":"name",
+            "value":"theme-color"
+         },
+         {
+            "key":"content",
+            "value":"#fff"
+         }
+      ],
+      "children":[
+
+      ]
+   }
+];
+
+let htmlArrayMock = [
+  '<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">',
+  '<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">',
+  '<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">',
+  '<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">',
+  '<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">',
+  '<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">',
+  '<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">',
+  '<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">',
+  '<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)" href="/apple-touch-startup-image-320x460.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)" href="/apple-touch-startup-image-640x920.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="/apple-touch-startup-image-640x1096.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="/apple-touch-startup-image-750x1294.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 3)" href="/apple-touch-startup-image-1182x2208.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 3)" href="/apple-touch-startup-image-1242x2148.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 1)" href="/apple-touch-startup-image-748x1024.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 2)" href="/apple-touch-startup-image-1496x2048.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 1)" href="/apple-touch-startup-image-768x1004.png">',
+  '<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 2)" href="/apple-touch-startup-image-1536x2008.png">',
+  '<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">',
+  '<link rel="icon" type="image/png" sizes="228x228" href="/coast-228x228.png">',
+  '<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">',
+  '<link rel="manifest" href="/manifest.json">',
+  '<link rel="shortcut icon" href="/favicon.ico">',
+  '<link rel="yandex-tableau-widget" href="/yandex-browser-manifest.json">',
+  '<meta name="apple-mobile-web-app-capable" content="yes">',
+  '<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">',
+  '<meta name="apple-mobile-web-app-title">',
+  '<meta name="application-name">',
+  '<meta name="mobile-web-app-capable" content="yes">',
+  '<meta name="msapplication-TileColor" content="#fff">',
+  '<meta name="msapplication-TileImage" content="/mstile-144x144.png">',
+  '<meta name="msapplication-config" content="/browserconfig.xml">',
+  '<meta name="theme-color" content="#fff">'
+];
+
+export default {
+  rawObjectsMock,
+  htmlArrayMock
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -49,7 +49,7 @@ describe('Favicon', function() {
     expect(fs.existsSync(path.join(builder.builder.outputPath, 'favicon-16x16.png'))).to.be.false;
   });
 
-  it('calls onSuccess callback wit proper data', async function() {
+  it('calls onSuccess callback with proper data', async function() {
     this.timeout(60000);
 
     let inputPath = path.join('tests', 'fixtures');

--- a/tests/index.js
+++ b/tests/index.js
@@ -51,7 +51,11 @@ describe('Favicon', function() {
     this.timeout(60000);
 
     let inputPath = path.join('tests', 'fixtures');
-    let onSuccess = (response) => { expect(response).to.be.ok }
+    let onSuccess = (html, rawObjects) => {
+      expect(html).to.be.ok;
+      expect(rawObjects).to.be.ok;
+    }
+
     let node = new Favicon(inputPath, { onSuccess });
     let builder = await createBuilder(node);
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,6 +8,8 @@ import Favicon from '../';
 import path from 'path';
 import fs from 'fs';
 
+import Mocks from './fixtures/mocks';
+
 const { expect } = chai;
 
 chai.config.truncateThreshold = 1000;
@@ -47,13 +49,13 @@ describe('Favicon', function() {
     expect(fs.existsSync(path.join(builder.builder.outputPath, 'favicon-16x16.png'))).to.be.false;
   });
 
-  it('calls onSuccess callback', async function() {
+  it('calls onSuccess callback wit proper data', async function() {
     this.timeout(60000);
 
     let inputPath = path.join('tests', 'fixtures');
     let onSuccess = (html, rawObjects) => {
-      expect(html).to.be.ok;
-      expect(rawObjects).to.be.ok;
+      expect(html).to.be.deep.equal(Mocks.htmlArrayMock);
+      expect(rawObjects).to.be.deep.equal(Mocks.rawObjectsMock);
     }
 
     let node = new Favicon(inputPath, { onSuccess });


### PR DESCRIPTION
Depends on: #39 

This PR will expose raw objects of HTML tags in the onSuccess hook to give a possibility of easier dom manipulation or possible transforms.