### PR TITLE
write images to outputPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ Default configuration values are show below:
 import Favicon from "broccoli-favicon";
 
 const outputNode = new Favicon(nodeWithFaviconImage, {
-  iconPath: "favicon.png", // The path to the source image in 'nodeWithFaviconImage'
+  // The path to the source image in 'nodeWithFaviconImage'
+  iconPath: "favicon.png",
+
+  // the sub path where the icon files will be written to. Defaults to writing to the root path.
+  outputPath: "favicons",
+
+  // this option enables/disables writing a "favicon.ico" copy at the root path
+  // this is useful if you use the `outputPath` option but still want to keep
+  // a favicon.ico copy at the root. Read more about why this is important: https://stackoverflow.com/a/21359390
+  placeIcoAtRoot: false,
 
   onSuccess(htmlArray, rawObject) {
     // this method is called once the generator finishes;

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,16 @@ export default class Favicon extends Plugin {
   }
 
   _saveFiles(files) {
+    let { faviconsConfig } = this.config;
+    let faviconsPath = faviconsConfig ? faviconsConfig.path || '' : '';
+    let outputPath = path.join(this.outputPath, faviconsPath);
+
+    if (!fs.existsSync(outputPath)) {
+      fs.mkdirSync(outputPath);
+    }
+
     files.forEach((file) =>
-      fs.writeFileSync(path.join(this.outputPath, file.name), file.contents)
+      fs.writeFileSync(path.join(outputPath, file.name), file.contents)
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default class Favicon extends Plugin {
 
   _saveFiles(files) {
     let { faviconsConfig } = this.config;
-    let faviconsPath = faviconsConfig ? faviconsConfig.path || '' : '';
+    let faviconsPath = faviconsConfig ? faviconsConfig.path || "" : "";
     let outputPath = path.join(this.outputPath, faviconsPath);
 
     if (!fs.existsSync(outputPath)) {

--- a/src/index.js
+++ b/src/index.js
@@ -58,16 +58,23 @@ export default class Favicon extends Plugin {
   }
 
   _saveFiles(files) {
-    let { faviconsConfig } = this.config;
-    let faviconsPath = faviconsConfig ? faviconsConfig.path || "" : "";
-    let outputPath = path.join(this.outputPath, faviconsPath);
+    let { outputPath, placeIcoAtRoot } = this.config;
+
+    let configPath = outputPath || "";
+    outputPath = path.join(this.outputPath, configPath);
+
+    placeIcoAtRoot = placeIcoAtRoot === undefined ? true : placeIcoAtRoot;
 
     if (!fs.existsSync(outputPath)) {
       fs.mkdirSync(outputPath);
     }
 
-    files.forEach((file) =>
-      fs.writeFileSync(path.join(outputPath, file.name), file.contents)
-    );
+    files.forEach((file) => {
+      fs.writeFileSync(path.join(outputPath, file.name), file.contents);
+
+      if (placeIcoAtRoot && outputPath !== "" && file.name === "favicon.ico") {
+        fs.writeFileSync(path.join(this.outputPath, file.name), file.contents);
+      }
+    });
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -41,13 +41,15 @@ describe("Favicon", function () {
     this.timeout(120000);
 
     let inputPath = path.join("tests", "fixtures");
-    let node = new Favicon(inputPath, { faviconsConfig: { path: "favicons" }});
+    let node = new Favicon(inputPath, { faviconsConfig: { path: "favicons" } });
     let builder = await createBuilder(node);
 
     await builder.build();
 
     expect(
-      fs.existsSync(path.join(builder.builder.outputPath, "favicons", "favicon-16x16.png"))
+      fs.existsSync(
+        path.join(builder.builder.outputPath, "favicons", "favicon-16x16.png")
+      )
     ).to.be.true;
   });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,6 +37,20 @@ describe("Favicon", function () {
     ).to.be.true;
   });
 
+  it("creates favicons inside folder", async function () {
+    this.timeout(120000);
+
+    let inputPath = path.join("tests", "fixtures");
+    let node = new Favicon(inputPath, { faviconsConfig: { path: "favicons" }});
+    let builder = await createBuilder(node);
+
+    await builder.build();
+
+    expect(
+      fs.existsSync(path.join(builder.builder.outputPath, "favicons", "favicon-16x16.png"))
+    ).to.be.true;
+  });
+
   it("does do nothing if there is no favicon", async function () {
     this.timeout(120000);
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -41,7 +41,7 @@ describe("Favicon", function () {
     this.timeout(120000);
 
     let inputPath = path.join("tests", "fixtures");
-    let node = new Favicon(inputPath, { faviconsConfig: { path: "favicons" } });
+    let node = new Favicon(inputPath, { outputPath: "favicons" });
     let builder = await createBuilder(node);
 
     await builder.build();
@@ -51,6 +51,30 @@ describe("Favicon", function () {
         path.join(builder.builder.outputPath, "favicons", "favicon-16x16.png")
       )
     ).to.be.true;
+
+    expect(fs.existsSync(path.join(builder.builder.outputPath, "favicon.ico")))
+      .to.be.true;
+  });
+
+  it("does not place favicon.ico in root if placeIcoAtRoot is false", async function () {
+    this.timeout(120000);
+
+    let inputPath = path.join("tests", "fixtures");
+    let node = new Favicon(inputPath, {
+      outputPath: "favicons",
+      placeIcoAtRoot: false,
+    });
+    let builder = await createBuilder(node);
+
+    await builder.build();
+
+    expect(
+      fs.existsSync(
+        path.join(builder.builder.outputPath, "favicons", "favicon-16x16.png")
+      )
+    ).to.be.true;
+    expect(fs.existsSync(path.join(builder.builder.outputPath, "favicon.ico")))
+      .to.be.false;
   });
 
   it("does do nothing if there is no favicon", async function () {


### PR DESCRIPTION
The favicon library supports the `path` option.
This option only changes the path at which the generated html and manifest point to. But the images were still being generated at the root directory.

This change respects that option, and puts the images in the correct place.